### PR TITLE
Introducing interfaces above the public-facing APIs

### DIFF
--- a/src/GitModel.AcceptanceTests/GitModel.AcceptanceTests.csproj
+++ b/src/GitModel.AcceptanceTests/GitModel.AcceptanceTests.csproj
@@ -79,7 +79,7 @@
     </Compile>
     <Compile Include="ModelObjects\CommitDocumentObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Steps\CommitSharedSteps.cs" />
+    <Compile Include="Steps\CommitSteps.cs" />
     <Compile Include="Transformations\StringTransformations.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GitModel.AcceptanceTests/Steps/CommitSteps.cs
+++ b/src/GitModel.AcceptanceTests/Steps/CommitSteps.cs
@@ -5,11 +5,11 @@ using GitModel.AcceptanceTests.ModelObjects;
 namespace GitModel.AcceptanceTests.Steps
 {
    [Binding]
-   public class CommitSharedSteps
+   public class CommitSteps
    {
       private readonly CommitDocumentObject _commitDocumentObject;
 
-      public CommitSharedSteps( CommitDocumentObject commitDocumentObject )
+      public CommitSteps( CommitDocumentObject commitDocumentObject )
       {
          _commitDocumentObject = commitDocumentObject;
       }

--- a/src/GitModel.UnitTests/CommitFileReaderTests.cs
+++ b/src/GitModel.UnitTests/CommitFileReaderTests.cs
@@ -3,6 +3,8 @@ using System.IO;
 using Xunit;
 using FluentAssertions;
 using Moq;
+using GitModel;
+using GitModel.Internal;
 using GitModel.UnitTests.Helpers;
 
 namespace GitModel.UnitTests

--- a/src/GitModel.UnitTests/CommitFileReaderTests.cs
+++ b/src/GitModel.UnitTests/CommitFileReaderTests.cs
@@ -11,12 +11,14 @@ namespace GitModel.UnitTests
 {
    public class CommitFileReaderTests
    {
-      [Fact]
-      public void FromFile_FilePathIsNull_ThrowsArgumentException()
+      [Theory]
+      [InlineData( null )]
+      [InlineData( "" )]
+      public void FromFile_FilePathIsInvalid_ThrowsArgumentException( string filePath )
       {
          var commitFileReader = new CommitFileReader( Mock.Of<IFileSystem>() );
 
-         Action fromFile = () => commitFileReader.FromFile( null );
+         Action fromFile = () => commitFileReader.FromFile( filePath );
 
          fromFile.ShouldThrow<ArgumentException>();
       }

--- a/src/GitModel.UnitTests/CommitFileWriterTests.cs
+++ b/src/GitModel.UnitTests/CommitFileWriterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -10,6 +11,18 @@ namespace GitModel.UnitTests
 {
    public class CommitFileWriterTests
    {
+      [Theory]
+      [InlineData( null )]
+      [InlineData( "" )]
+      public void ToFile_FilePathIsInvalid_ThrowsArgumentException( string filePath )
+      {
+         var commitFileWriter = new CommitFileWriter( Mock.Of<IFileSystem>() );
+
+         Action fromFile = () => commitFileWriter.ToFile( filePath, new CommitDocument() );
+
+         fromFile.ShouldThrow<ArgumentException>();
+      }
+
       [Fact]
       public void ToFile_CommitDocumentHasSubject_SubjectIsWritten()
       {

--- a/src/GitModel.UnitTests/CommitFileWriterTests.cs
+++ b/src/GitModel.UnitTests/CommitFileWriterTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Xunit;
 using Moq;
 using GitModel;
+using GitModel.Internal;
 
 namespace GitModel.UnitTests
 {

--- a/src/GitModel.UnitTests/CommitFileWriterTests.cs
+++ b/src/GitModel.UnitTests/CommitFileWriterTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Policy;
 using FluentAssertions;
 using Xunit;
 using Moq;

--- a/src/GitModel.UnitTests/CommitFileWriterTests.cs
+++ b/src/GitModel.UnitTests/CommitFileWriterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Policy;
 using FluentAssertions;
 using Xunit;
 using Moq;
@@ -19,6 +20,16 @@ namespace GitModel.UnitTests
          var commitFileWriter = new CommitFileWriter( Mock.Of<IFileSystem>() );
 
          Action fromFile = () => commitFileWriter.ToFile( filePath, new CommitDocument() );
+
+         fromFile.ShouldThrow<ArgumentException>();
+      }
+
+      [Fact]
+      public void ToFile_CommitDocumentIsNull_ThrowsArgumentException()
+      {
+         var commitFileWriter = new CommitFileWriter( Mock.Of<IFileSystem>() );
+
+         Action fromFile = () => commitFileWriter.ToFile( "NotNullString", null );
 
          fromFile.ShouldThrow<ArgumentException>();
       }

--- a/src/GitModel/CommitFileReader.cs
+++ b/src/GitModel/CommitFileReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GitModel.Internal;
 
 namespace GitModel
 {

--- a/src/GitModel/CommitFileReader.cs
+++ b/src/GitModel/CommitFileReader.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace GitModel
 {
-   public class CommitFileReader
+   public class CommitFileReader : ICommitFileReader
    {
       private readonly IFileSystem _fileSystem;
 

--- a/src/GitModel/CommitFileWriter.cs
+++ b/src/GitModel/CommitFileWriter.cs
@@ -24,6 +24,11 @@ namespace GitModel
             throw new ArgumentException( "File path must not be null or empty", nameof( filePath ) );
          }
 
+         if ( document == null )
+         {
+            throw new ArgumentException( "Commit document must not be null", nameof( document ) );
+         }
+
          var lines = new List<string>
          {
             document.Subject

--- a/src/GitModel/CommitFileWriter.cs
+++ b/src/GitModel/CommitFileWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GitModel.Internal;
 
 namespace GitModel
@@ -18,6 +19,11 @@ namespace GitModel
 
       public void ToFile( string filePath, CommitDocument document )
       {
+         if ( string.IsNullOrEmpty( filePath ) )
+         {
+            throw new ArgumentException( "File path must not be null or empty", nameof( filePath ) );
+         }
+
          var lines = new List<string>
          {
             document.Subject

--- a/src/GitModel/CommitFileWriter.cs
+++ b/src/GitModel/CommitFileWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using GitModel.Internal;
 
 namespace GitModel
 {

--- a/src/GitModel/CommitFileWriter.cs
+++ b/src/GitModel/CommitFileWriter.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace GitModel
 {
-   public class CommitFileWriter
+   public class CommitFileWriter : ICommitFileWriter
    {
       private readonly IFileSystem _fileSystem;
 

--- a/src/GitModel/ICommitFileReader.cs
+++ b/src/GitModel/ICommitFileReader.cs
@@ -1,0 +1,7 @@
+﻿namespace GitModel
+{
+   public interface ICommitFileReader
+   {
+      CommitDocument FromFile( string filePath );
+   }
+}

--- a/src/GitModel/ICommitFileWriter.cs
+++ b/src/GitModel/ICommitFileWriter.cs
@@ -1,0 +1,7 @@
+﻿namespace GitModel
+{
+   public interface ICommitFileWriter
+   {
+      void ToFile( string filePath, CommitDocument document );
+   }
+}

--- a/src/GitModel/Internal/FileSystem.cs
+++ b/src/GitModel/Internal/FileSystem.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 
-namespace GitModel
+namespace GitModel.Internal
 {
    internal class FileSystem : IFileSystem
    {

--- a/src/GitModel/Internal/IFileSystem.cs
+++ b/src/GitModel/Internal/IFileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace GitModel
+namespace GitModel.Internal
 {
    internal interface IFileSystem
    {


### PR DESCRIPTION
Just as a nicety for the end-user, in case they want to hand around abstractions, they shouldn't have to roll their own. Also minor cleanup (RIP SRP).